### PR TITLE
Harden CI routing and immutable firmware checks

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,10 +27,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Test routing and packaging policy helpers
         run: python3 -B -m unittest discover -s tests -v
       - name: Check limited first-party documentation policy
         run: python3 -B scripts/check_repository_policy.py --config repository_policy.json
+      - name: Verify immutable factory firmware identities
+        env:
+          FIRMWARE_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.ref_type == 'branch' && github.event.before) || '' }}
+        run: |
+          arguments=()
+          if [[ -n "$FIRMWARE_BASE_REF" ]]; then
+            arguments+=(--base-ref "$FIRMWARE_BASE_REF")
+          fi
+          python3 -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json "${arguments[@]}"
 
   discover-esp-idf:
     needs: repository-policy
@@ -43,6 +54,8 @@ jobs:
       firmware: ${{ steps.discover.outputs.firmware }}
       release_review: ${{ steps.discover.outputs.release_review }}
       unknown_paths: ${{ steps.discover.outputs.unknown_paths }}
+      firmware_paths: ${{ steps.discover.outputs.firmware_paths }}
+      release_paths: ${{ steps.discover.outputs.release_paths }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -61,8 +74,67 @@ jobs:
             --idf-versions v5.5.5,v6.0.2 \
             --github-output "$GITHUB_OUTPUT"
 
+  change-scope:
+    needs: [discover-esp-idf, discover-arduino]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require both classifiers
+        if: needs.discover-esp-idf.result != 'success' || needs.discover-arduino.result != 'success'
+        run: |
+          echo "A complete change classification is required." >&2
+          exit 1
+      - name: Publish change scope
+        if: needs.discover-esp-idf.result == 'success' && needs.discover-arduino.result == 'success'
+        env:
+          DOCS_ONLY: ${{ needs.discover-esp-idf.outputs.docs_only }}
+          FIRMWARE: ${{ needs.discover-esp-idf.outputs.firmware }}
+          RELEASE_REVIEW: ${{ needs.discover-esp-idf.outputs.release_review }}
+          FIRMWARE_PATHS: ${{ needs.discover-esp-idf.outputs.firmware_paths }}
+          RELEASE_PATHS: ${{ needs.discover-esp-idf.outputs.release_paths }}
+          UNKNOWN_PATHS: ${{ needs.discover-esp-idf.outputs.unknown_paths }}
+          ESP_IDF_ROUTE: ${{ needs.discover-esp-idf.outputs.route }}
+          ARDUINO_ROUTE: ${{ needs.discover-arduino.outputs.route }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          def paths(name):
+              value = json.loads(os.environ[name] or "[]")
+              if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+                  raise SystemExit(f"invalid classifier output: {name}")
+              return value
+
+          firmware_paths = paths("FIRMWARE_PATHS")
+          release_paths = paths("RELEASE_PATHS")
+          unknown_paths = paths("UNKNOWN_PATHS")
+          rows = [
+              "## Change scope",
+              "",
+              f"- Documentation only: `{os.environ['DOCS_ONLY']}`",
+              f"- Firmware surface: `{os.environ['FIRMWARE']}`",
+              f"- Immutable artifact review: `{os.environ['RELEASE_REVIEW']}`",
+              f"- ESP-IDF route: `{os.environ['ESP_IDF_ROUTE']}`",
+              f"- Arduino route: `{os.environ['ARDUINO_ROUTE']}`",
+              f"- Firmware paths: `{json.dumps(firmware_paths, separators=(',', ':'))}`",
+              f"- Release-review paths: `{json.dumps(release_paths, separators=(',', ':'))}`",
+              f"- Unknown paths: `{json.dumps(unknown_paths, separators=(',', ':'))}`",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(rows) + "\n")
+          if os.environ["DOCS_ONLY"] == "true":
+              print("::notice::Documentation-only change; example builds are skipped by design.")
+          if firmware_paths:
+              print("::notice::Firmware paths are reported separately and remain outside example CI.")
+          if release_paths:
+              print("::warning::Immutable firmware or release metadata changed; maintainer release review is required.")
+          if unknown_paths:
+              print("::warning::Unknown non-document paths conservatively select all example builds.")
+          PY
+
   build-esp-idf:
-    needs: discover-esp-idf
+    needs: [discover-esp-idf, change-scope]
     if: needs.discover-esp-idf.outputs.route != 'none'
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf }}
@@ -73,21 +145,30 @@ jobs:
       - uses: actions/checkout@v7
       - name: Build ${{ matrix.path }} with ESP-IDF ${{ matrix.idf }}
         shell: bash
+        env:
+          PROJECT_PATH: ${{ matrix.path }}
+          BUILD_PATH: build/${{ matrix.name }}-${{ matrix.idf }}
         run: |
           . "$IDF_PATH/export.sh"
           idf.py --version
-          idf.py -C "${{ matrix.path }}" -B "build/${{ matrix.name }}-${{ matrix.idf }}" set-target esp32s3 build
+          idf.py -C "$PROJECT_PATH" -B "$BUILD_PATH" set-target esp32s3 build
       - name: Package firmware
         shell: bash
+        env:
+          PROJECT_PATH: ${{ matrix.path }}
+          BUILD_PATH: build/${{ matrix.name }}-${{ matrix.idf }}
+          PACKAGE_NAME: ESP32-S3-Touch-AMOLED-1.8-${{ matrix.name }}-esp-idf-${{ matrix.idf }}-esp32s3
+          FRAMEWORK_VERSION: ${{ matrix.idf }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           python3 releases/package_firmware.py \
             --framework esp-idf \
-            --project "${{ matrix.path }}" \
-            --build-dir "build/${{ matrix.name }}-${{ matrix.idf }}" \
-            --name "ESP32-S3-Touch-AMOLED-1.8-${{ matrix.name }}-esp-idf-${{ matrix.idf }}-esp32s3" \
-            --framework-version "${{ matrix.idf }}" \
+            --project "$PROJECT_PATH" \
+            --build-dir "$BUILD_PATH" \
+            --name "$PACKAGE_NAME" \
+            --framework-version "$FRAMEWORK_VERSION" \
             --target esp32s3 \
-            --git-sha "${{ github.sha }}" \
+            --git-sha "$COMMIT_SHA" \
             --output-dir release-artifacts
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v7
@@ -107,6 +188,8 @@ jobs:
       firmware: ${{ steps.discover.outputs.firmware }}
       release_review: ${{ steps.discover.outputs.release_review }}
       unknown_paths: ${{ steps.discover.outputs.unknown_paths }}
+      firmware_paths: ${{ steps.discover.outputs.firmware_paths }}
+      release_paths: ${{ steps.discover.outputs.release_paths }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -127,7 +210,7 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
 
   build-arduino:
-    needs: discover-arduino
+    needs: [discover-arduino, change-scope]
     if: needs.discover-arduino.outputs.route != 'none'
     runs-on: ubuntu-latest
     strategy:
@@ -137,29 +220,42 @@ jobs:
       - uses: actions/checkout@v7
       - uses: arduino/setup-arduino-cli@v2
       - name: Install ESP32 Arduino core
+        env:
+          ARDUINO_CORE: ${{ matrix.core }}
         run: |
           arduino-cli config init --overwrite
           arduino-cli config add board_manager.additional_urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
           arduino-cli core update-index
-          arduino-cli core install esp32:esp32@${{ matrix.core }}
+          arduino-cli core install "esp32:esp32@$ARDUINO_CORE"
       - name: Compile ${{ matrix.path }}
+        env:
+          FQBN: ${{ matrix.fqbn }}
+          LIBRARIES: ${{ matrix.libraries }}
+          BUILD_PATH: build/${{ matrix.name }}-${{ matrix.core }}
+          PROJECT_PATH: ${{ matrix.path }}
         run: |
           arduino-cli compile \
-            --fqbn "${{ matrix.fqbn }}" \
-            --libraries "${{ matrix.libraries }}" \
+            --fqbn "$FQBN" \
+            --libraries "$LIBRARIES" \
             --export-binaries \
-            --output-dir "build/${{ matrix.name }}-${{ matrix.core }}" \
-            "${{ matrix.path }}"
+            --output-dir "$BUILD_PATH" \
+            "$PROJECT_PATH"
       - name: Package firmware
+        env:
+          PROJECT_PATH: ${{ matrix.path }}
+          BUILD_PATH: build/${{ matrix.name }}-${{ matrix.core }}
+          PACKAGE_NAME: ESP32-S3-Touch-AMOLED-1.8-${{ matrix.name }}-arduino-${{ matrix.core }}-esp32s3
+          FRAMEWORK_VERSION: ${{ matrix.core }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           python3 releases/package_firmware.py \
             --framework arduino \
-            --project "${{ matrix.path }}" \
-            --build-dir "build/${{ matrix.name }}-${{ matrix.core }}" \
-            --name "ESP32-S3-Touch-AMOLED-1.8-${{ matrix.name }}-arduino-${{ matrix.core }}-esp32s3" \
-            --framework-version "${{ matrix.core }}" \
+            --project "$PROJECT_PATH" \
+            --build-dir "$BUILD_PATH" \
+            --name "$PACKAGE_NAME" \
+            --framework-version "$FRAMEWORK_VERSION" \
             --target esp32s3 \
-            --git-sha "${{ github.sha }}" \
+            --git-sha "$COMMIT_SHA" \
             --output-dir release-artifacts
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v7

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -14,7 +14,7 @@ The workflow uses `scripts/discover_examples.py` for both framework surfaces:
 
 `workflow_dispatch` accepts `all`, an example directory name, or a repo-relative example path. Maintainers can run the full matrix or a single example.
 
-The repository-policy job is always visible on pull requests. Its routing contract fails closed: unavailable or incomplete diff data is an error, not a fallback build or pass. Documentation-only changes, including `Firmware/` documentation or immutable binaries, are reported without default example builds; `Firmware/` remains outside the example matrix. A usable pull request or branch diff builds only affected first-party examples. A bundled-library change rebuilds all first-party sketches in the matching Arduino root. Workflow, discovery, policy, routing, or release-packaging changes run the relevant full framework surface; shared ESP-IDF configuration changes rebuild the ESP-IDF surface. Tag pushes and manual `all` runs build the full matrix.
+The repository-policy job is always visible on pull requests. Its routing contract fails closed: unavailable or incomplete diff data is an error, not a fallback build or pass. A separate `change-scope` job consumes and publishes the documentation-only, firmware, immutable-artifact-review, and unknown-path classifier outputs. Documentation-only changes select no example builds. Every `Firmware/` file kind is reported separately and remains outside the example matrix; binary or archive paths also receive an explicit release-review warning. A usable pull request or branch diff builds only affected first-party examples. A bundled-library change rebuilds all first-party sketches in the matching Arduino root. Workflow, discovery, policy, routing, or release-packaging changes run the relevant full framework surface; shared ESP-IDF configuration changes rebuild the ESP-IDF surface. Tag pushes and manual `all` runs build the full matrix.
 
 Manual runs can build the full matrix or narrow it by passing an example name, a parent example directory such as `08_LVGL_Animation`, or a repo-relative path to `target`.
 
@@ -25,7 +25,7 @@ Current CI matrix:
 - ESP-IDF `v5.5.5` and `v6.0.2`, target `esp32s3`.
 - Arduino-ESP32 core `3.3.11`, FQBN `esp32:esp32:esp32s3:FlashSize=16M,PartitionScheme=app3M_fat9M_16MB`, using bundled libraries from the matching `examples/arduino/libraries` or `examples/arduino-v2/libraries` directory.
 
-The selected framework versions were reverified from official stable releases on 2026-08-10: ESP-IDF `v5.5.5` and `v6.0.2`, plus Arduino-ESP32 `3.3.11`. The ESP-IDF coverage retains the v5.5-to-v6.0 migration context. Do not replace them with beta, release-candidate, preview, or nightly tags unless the repository intentionally opts into that coverage.
+The selected framework versions were reverified from official stable releases on 2026-08-13: ESP-IDF `v5.5.5` and `v6.0.2`, plus Arduino-ESP32 `3.3.11`. The ESP-IDF coverage retains the v5.5-to-v6.0 migration context. Do not replace them with beta, release-candidate, preview, or nightly tags unless the repository intentionally opts into that coverage.
 
 The full matrix contains 60 firmware build jobs: 17 ESP-IDF examples for each of two ESP-IDF versions, plus 16 original and 10 V2 Arduino sketches.
 
@@ -44,7 +44,7 @@ Download the artifact zip from the workflow run, extract it, then run `flash.sh`
 
 Generated archives are workflow artifacts only. Do not commit generated files from `release-artifacts/`, `releases/dist/`, or `releases/downloads/`.
 
-Checked-in files under `Firmware/` are factory or recovery binaries. They are documented assets, not source-build outputs, and they do not trigger source-build packaging.
+Checked-in files under `Firmware/` are factory or recovery binaries. They are documented assets, not source-build outputs, and they do not trigger source-build packaging. The lightweight policy job checks each tracked factory binary against the repository-relative path, byte size, and SHA-256 identity in `firmware_integrity.json`; on pull requests and branch pushes it also compares the binaries with the trusted base commit. It fails on missing, modified, unsafe, or unlisted tracked `.bin` files without rebuilding or repackaging them.
 
 ## Hardware Validation Boundary
 
@@ -63,9 +63,10 @@ python scripts/discover_examples.py --surface arduino --selector all
 python scripts/discover_examples.py --surface arduino --selector 08_LVGL_Animation
 python -B -m unittest discover -s tests -v
 python -B scripts/check_repository_policy.py --config repository_policy.json
+python -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json
 ```
 
-The last two commands are the exact non-build checks for the repository policy and its tests. Product builds are a separate local or GitHub Actions responsibility; these checks do not compile examples or validate hardware.
+The last three commands are the exact non-build checks for the repository policy, immutable firmware identities, and their tests. Product builds are a separate local or GitHub Actions responsibility; these checks do not compile examples or validate hardware.
 
 The packaging helper expects an existing ESP-IDF or Arduino build output and is normally exercised inside CI after the framework build finishes.
 

--- a/docs/CI_ZH.md
+++ b/docs/CI_ZH.md
@@ -14,7 +14,7 @@
 
 `workflow_dispatch` 接受 `all`、示例目录名或仓库相对示例路径。维护者可运行完整矩阵或单个示例。
 
-仓库策略作业在拉取请求中始终可见。其路由契约为失败关闭：不可用或不完整的差异数据是错误，而不是回退构建或通过。仅文档变更（包括 `Firmware/` 文档或不可变二进制文件）会被报告但默认不构建示例；`Firmware/` 不属于示例矩阵。可用的拉取请求或分支差异仅构建受影响的第一方示例。捆绑库变更会重建同一 Arduino 根目录的全部第一方草图。工作流、发现、策略、路由或发布打包变更运行相关框架的完整表面；共享 ESP-IDF 配置变更重建 ESP-IDF 表面。标签推送和手动 `all` 运行构建完整矩阵。
+仓库策略作业在拉取请求中始终可见。其路由契约为失败关闭：不可用或不完整的差异数据是错误，而不是回退构建或通过。独立的 `change-scope` 作业会消费并发布“仅文档”“固件”“不可变工件复核”和“未知路径”分类输出。仅文档变更不选择示例构建。`Firmware/` 下的每种文件都会单独报告且始终不进入示例矩阵；二进制或归档路径还会产生明确的发布复核警告。可用的拉取请求或分支差异仅构建受影响的第一方示例。捆绑库变更会重建同一 Arduino 根目录的全部第一方草图。工作流、发现、策略、路由或发布打包变更运行相关框架的完整表面；共享 ESP-IDF 配置变更重建 ESP-IDF 表面。标签推送和手动 `all` 运行构建完整矩阵。
 
 手动运行可通过 `target` 指定示例名、父目录（如 `08_LVGL_Animation`）或仓库相对路径。
 
@@ -25,7 +25,7 @@
 - ESP-IDF `v5.5.5` 和 `v6.0.2`，目标 `esp32s3`。
 - Arduino-ESP32 core `3.3.11`，FQBN `esp32:esp32:esp32s3:FlashSize=16M,PartitionScheme=app3M_fat9M_16MB`，使用对应 `examples/arduino/libraries` 或 `examples/arduino-v2/libraries` 目录中的捆绑库。
 
-这些框架版本已于 2026-08-10 从官方稳定版发布重新核实：ESP-IDF `v5.5.5`、`v6.0.2` 与 Arduino-ESP32 `3.3.11`。ESP-IDF 覆盖保留 v5.5 到 v6.0 的迁移背景，不使用 beta、release-candidate、preview 或 nightly 标签。完整矩阵包含 60 个固件构建作业：17 个 ESP-IDF 示例分别针对两个 ESP-IDF 版本，加上 16 个原版和 10 个 V2 Arduino 草图。
+这些框架版本已于 2026-08-13 从官方稳定版发布重新核实：ESP-IDF `v5.5.5`、`v6.0.2` 与 Arduino-ESP32 `3.3.11`。ESP-IDF 覆盖保留 v5.5 到 v6.0 的迁移背景，不使用 beta、release-candidate、preview 或 nightly 标签。完整矩阵包含 60 个固件构建作业：17 个 ESP-IDF 示例分别针对两个 ESP-IDF 版本，加上 16 个原版和 10 个 V2 Arduino 草图。
 
 ## 固件工件
 
@@ -38,7 +38,7 @@
 - 带 esptool 命令参数的 `flash_args.txt`
 - `bin/` 下由清单引用的固件二进制文件
 
-从工作流运行下载工件 zip，解压后使用开发板串口运行 `flash.sh` 或 `flash.bat`。CI zip 名称包含框架、示例、框架版本、目标和短提交标识；外层 GitHub 工件名称保持稳定，便于筛选和脚本下载。生成归档仅是工作流工件，不要提交 `release-artifacts/`、`releases/dist/` 或 `releases/downloads/` 中生成的文件。`Firmware/` 下检入的是工厂或恢复二进制文件，是文档化资产而非源码构建输出，也不会触发源码构建打包。
+从工作流运行下载工件 zip，解压后使用开发板串口运行 `flash.sh` 或 `flash.bat`。CI zip 名称包含框架、示例、框架版本、目标和短提交标识；外层 GitHub 工件名称保持稳定，便于筛选和脚本下载。生成归档仅是工作流工件，不要提交 `release-artifacts/`、`releases/dist/` 或 `releases/downloads/` 中生成的文件。`Firmware/` 下检入的是工厂或恢复二进制文件，是文档化资产而非源码构建输出，也不会触发源码构建打包。轻量策略作业根据 `firmware_integrity.json` 中的仓库相对路径、字节大小和 SHA-256 身份核验每个已跟踪工厂二进制；在拉取请求和分支推送中，它还会把二进制与可信基线提交比较。对于缺失、被修改、不安全或未列入清单的已跟踪 `.bin` 文件，它会失败且不会重建或重新打包固件。
 
 ## 硬件验证边界
 
@@ -55,6 +55,7 @@ python scripts/discover_examples.py --surface arduino --selector all
 python scripts/discover_examples.py --surface arduino --selector 08_LVGL_Animation
 python -B -m unittest discover -s tests -v
 python -B scripts/check_repository_policy.py --config repository_policy.json
+python -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json
 ```
 
-最后两条是仓库策略及其测试的精确非构建检查；产品构建是独立的本地或 GitHub Actions 责任，这些检查不编译示例或验证硬件。打包辅助工具需要现有 ESP-IDF 或 Arduino 构建输出，通常在框架构建完成后由 CI 运行。如示例需要硬件、凭据或尚不兼容所选框架版本的上游组件，请在此记录排除原因后再将其排除出 CI。
+最后三条是仓库策略、不可变固件身份及其测试的精确非构建检查；产品构建是独立的本地或 GitHub Actions 责任，这些检查不编译示例或验证硬件。打包辅助工具需要现有 ESP-IDF 或 Arduino 构建输出，通常在框架构建完成后由 CI 运行。如示例需要硬件、凭据或尚不兼容所选框架版本的上游组件，请在此记录排除原因后再将其排除出 CI。

--- a/firmware_integrity.json
+++ b/firmware_integrity.json
@@ -1,0 +1,14 @@
+{
+  "firmware": [
+    {
+      "path": "Firmware/ESP32-S3-Touch-AMOLED-1.8-FactoryXiaozhi_250805.bin",
+      "size": 16732160,
+      "sha256": "033ba27f0d1824835e90fe6b41d2db8c1f13cda7e1d80c82b3f7537dafb8dc8d"
+    },
+    {
+      "path": "Firmware/ESP32-S3-Touch-AMOLED-1.8-V2-FactoryXiaozhi_260601.bin",
+      "size": 16777216,
+      "sha256": "6f188fb9d35ee793a3423934a4fa4e7c1fef9cc9dae76f9f177dabe854a6cdb3"
+    }
+  ]
+}

--- a/scripts/check_firmware_integrity.py
+++ b/scripts/check_firmware_integrity.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Verify the immutable identities of tracked factory firmware binaries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+
+def safe_firmware_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError("firmware path must be a non-empty repository-relative POSIX path")
+    path = PurePosixPath(value)
+    if (path.is_absolute() or len(path.parts) != 2 or path.parts[:1] != ("Firmware",)
+            or path.suffix != ".bin"
+            or any(part in {"", ".", ".."} for part in path.parts)):
+        raise ValueError("firmware path must name a .bin directly under the case-sensitive Firmware root")
+    return path.as_posix()
+
+
+def load_manifest(path: Path) -> list[dict[str, object]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or set(data) != {"firmware"} or not isinstance(data["firmware"], list):
+        raise ValueError("manifest must contain only a firmware list")
+    entries: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for item in data["firmware"]:
+        if not isinstance(item, dict) or set(item) != {"path", "size", "sha256"}:
+            raise ValueError("each firmware entry must contain only path, size, and sha256")
+        relative = safe_firmware_path(item["path"])
+        if relative in seen:
+            raise ValueError("firmware paths must be unique")
+        if not isinstance(item["size"], int) or isinstance(item["size"], bool) or item["size"] < 0:
+            raise ValueError("firmware size must be a non-negative integer")
+        digest = item["sha256"]
+        if not isinstance(digest, str) or len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+            raise ValueError("firmware sha256 must be a lowercase 64-character hexadecimal digest")
+        seen.add(relative)
+        entries.append({"path": relative, "size": item["size"], "sha256": digest})
+    if not entries:
+        raise ValueError("firmware list must not be empty")
+    return entries
+
+
+def git_root(cwd: Path) -> Path:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], cwd=cwd, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError("unable to determine the repository root") from exc
+    return Path(completed.stdout.decode("utf-8", "surrogateescape").strip())
+
+
+def manifest_at_root(repo: Path, requested: Path) -> Path:
+    candidate = requested if requested.is_absolute() else Path.cwd() / requested
+    candidate = candidate.absolute()
+    expected = repo / "firmware_integrity.json"
+    if candidate != expected:
+        raise ValueError("manifest must be firmware_integrity.json at the repository root")
+    metadata = candidate.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or candidate.is_symlink():
+        raise ValueError("manifest must be a regular non-symlink file")
+    return candidate
+
+
+def tracked_firmware_bins(repo: Path, revision: str | None = None) -> set[str]:
+    command = (["git", "ls-tree", "-r", "-z", "--name-only", revision, "--", "Firmware"]
+               if revision else ["git", "ls-files", "-z", "--", "Firmware"])
+    try:
+        completed = subprocess.run(
+            command, cwd=repo, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        scope = f" at {revision}" if revision else ""
+        raise RuntimeError(f"unable to enumerate tracked Firmware files{scope}") from exc
+    return {item for item in completed.stdout.decode("utf-8", "surrogateescape").split("\0")
+            if item.startswith("Firmware/") and item.lower().endswith(".bin")}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def revision_blob_identity(repo: Path, revision: str, relative: str) -> tuple[int, str]:
+    try:
+        completed = subprocess.run(
+            ["git", "show", f"{revision}:{relative}"], cwd=repo, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"unable to read immutable firmware from {revision}: {relative}") from exc
+    return len(completed.stdout), hashlib.sha256(completed.stdout).hexdigest()
+
+
+def check(repo: Path, manifest: list[dict[str, object]], base_ref: str | None = None) -> list[str]:
+    findings: list[str] = []
+    listed = {entry["path"] for entry in manifest}
+    try:
+        tracked = tracked_firmware_bins(repo)
+    except RuntimeError as exc:
+        return [str(exc)]
+    for path in sorted(tracked - listed):
+        findings.append(f"UNLISTED_TRACKED_FIRMWARE: {path}")
+    for entry in manifest:
+        relative = str(entry["path"])
+        path = repo / relative
+        if relative not in tracked:
+            findings.append(f"UNTRACKED_FIRMWARE: {relative}")
+            continue
+        try:
+            metadata = path.lstat()
+        except OSError:
+            findings.append(f"MISSING_FIRMWARE: {relative}")
+            continue
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            findings.append(f"UNSAFE_FIRMWARE: {relative}")
+            continue
+        if metadata.st_size != entry["size"]:
+            findings.append(f"SIZE_MISMATCH: {relative}")
+            continue
+        try:
+            actual = sha256(path)
+        except OSError:
+            findings.append(f"UNREADABLE_FIRMWARE: {relative}")
+            continue
+        if actual != entry["sha256"]:
+            findings.append(f"SHA256_MISMATCH: {relative}")
+    if base_ref:
+        try:
+            base_tracked = tracked_firmware_bins(repo, base_ref)
+        except RuntimeError as exc:
+            return findings + [str(exc)]
+        for relative in sorted(tracked - base_tracked):
+            findings.append(f"IMMUTABLE_FIRMWARE_ADDED: {relative}")
+        for relative in sorted(base_tracked - tracked):
+            findings.append(f"IMMUTABLE_FIRMWARE_REMOVED: {relative}")
+        for relative in sorted(tracked & base_tracked):
+            path = repo / relative
+            try:
+                metadata = path.lstat()
+                if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                    continue
+                base_size, base_digest = revision_blob_identity(repo, base_ref, relative)
+                if metadata.st_size != base_size or sha256(path) != base_digest:
+                    findings.append(f"IMMUTABLE_FIRMWARE_CHANGED: {relative}")
+            except (OSError, RuntimeError) as exc:
+                findings.append(str(exc))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="firmware_integrity.json")
+    parser.add_argument("--base-ref", help="trusted Git revision whose factory binaries must remain unchanged")
+    args = parser.parse_args()
+    try:
+        repo = git_root(Path.cwd())
+        config = manifest_at_root(repo, Path(args.manifest))
+        manifest = load_manifest(config)
+        findings = check(repo, manifest, args.base_ref)
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"CONFIG_ERROR: {exc}", file=sys.stderr)
+        return 2
+    for finding in findings:
+        print(finding)
+    if findings:
+        return 1
+    print(f"PASS: verified {len(manifest)} immutable factory firmware identities")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discover_examples.py
+++ b/scripts/discover_examples.py
@@ -17,6 +17,7 @@ ARDUINO_ROOTS = (Path("examples/arduino"), Path("examples/arduino-v2"))
 DOC_SUFFIXES = {".md", ".markdown", ".rst"}
 ARCHIVE_SUFFIXES = {".bin", ".zip", ".7z", ".tar", ".gz", ".xz"}
 GLOBAL_PREFIXES = (".github/workflows/", "tests/", "scripts/", "releases/", "repository_policy.json")
+FIRMWARE_POLICY_PATHS = {"firmware_integrity.json"}
 
 
 class DiffUnavailable(RuntimeError):
@@ -136,6 +137,10 @@ def classify_paths(paths: list[str], surface: str, examples: list[dict[str, str]
         lower = changed.lower()
         if not changed:
             continue
+        if lower in FIRMWARE_POLICY_PATHS:
+            firmware_paths.append(changed)
+            release_review_paths.append(changed)
+            continue
         if lower == "firmware" or lower.startswith("firmware/"):
             firmware_paths.append(changed)
             if Path(lower).suffix in ARCHIVE_SUFFIXES:
@@ -169,7 +174,8 @@ def classify_paths(paths: list[str], surface: str, examples: list[dict[str, str]
         selected = [example for example in examples if example["path"] in selected_paths]
     route = "all" if len(selected) == len(examples) and selected else "selected" if selected else "none"
     return selected, {"route": route, "docs_only": bool(paths) and non_docs == 0 and not firmware_paths,
-                      "firmware": bool(firmware_paths), "release_review": bool(release_review_paths),
+                      "firmware": bool(firmware_paths), "firmware_paths": firmware_paths,
+                      "release_review": bool(release_review_paths), "release_paths": release_review_paths,
                       "unknown_paths": unknown, "changed_paths": paths}
 
 
@@ -213,8 +219,9 @@ def main() -> int:
         if args.mode == "all" or selector:
             selected = [example for example in examples if matches_selector(example, selector)]
             evidence = {"route": "all" if len(selected) == len(examples) else "selected" if selected else "none",
-                        "docs_only": False, "firmware": False, "release_review": False,
-                        "unknown_paths": [], "changed_paths": []}
+                        "docs_only": False, "firmware": False, "firmware_paths": [],
+                        "release_review": False, "release_paths": [], "unknown_paths": [],
+                        "changed_paths": []}
         else:
             paths = parse_changed_file_input(Path(args.changed_files_from)) if args.changed_files_from else git_changed_paths(args.base_ref, args.head_ref)
             selected, evidence = classify_paths(paths, args.surface, examples)

--- a/tests/test_discover_examples.py
+++ b/tests/test_discover_examples.py
@@ -86,6 +86,12 @@ class DiscoverExamplesCliTests(unittest.TestCase):
             self.assertFalse(result["docs_only"])
         release = self.result("arduino", "Firmware/image.bin\n")
         self.assertTrue(release["release_review"])
+        self.assertEqual(release["firmware_paths"], ["Firmware/image.bin"])
+        self.assertEqual(release["release_paths"], ["Firmware/image.bin"])
+        manifest = self.result("esp-idf", "firmware_integrity.json\n")
+        self.assertEqual(manifest["route"], "none")
+        self.assertEqual(manifest["firmware_paths"], ["firmware_integrity.json"])
+        self.assertEqual(manifest["release_paths"], ["firmware_integrity.json"])
         unknown = self.result("esp-idf", "new-build-input.toml\n")
         self.assertEqual(unknown["route"], "all")
         self.assertEqual(unknown["unknown_paths"], ["new-build-input.toml"])
@@ -162,7 +168,8 @@ class DiscoverExamplesCliTests(unittest.TestCase):
         self.assertIn(new.relative_to(root).as_posix(), result["changed_paths"])
         output_values = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
         self.assertEqual(output_values["count"], str(expected_count))
-        for key in ("matrix", "route", "docs_only", "firmware", "release_review", "unknown_paths", "changed_paths"):
+        for key in ("matrix", "route", "docs_only", "firmware", "firmware_paths", "release_review",
+                    "release_paths", "unknown_paths", "changed_paths"):
             self.assertIn(key, output_values)
 
 

--- a/tests/test_firmware_integrity.py
+++ b/tests/test_firmware_integrity.py
@@ -1,0 +1,130 @@
+"""Synthetic CLI tests for immutable factory firmware identity checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "check_firmware_integrity.py"
+
+
+class FirmwareIntegrityCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        (self.root / "Firmware").mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+
+    def write_binary(self, name: str, content: bytes = b"factory-image") -> Path:
+        path = self.root / "Firmware" / name
+        path.write_bytes(content)
+        subprocess.run(["git", "add", path.relative_to(self.root).as_posix()], cwd=self.root, check=True)
+        return path
+
+    def write_manifest(self, entries: list[dict[str, object]]) -> Path:
+        path = self.root / "firmware_integrity.json"
+        path.write_text(json.dumps({"firmware": entries}), encoding="utf-8")
+        return path
+
+    @staticmethod
+    def entry(path: Path, content: bytes) -> dict[str, object]:
+        return {
+            "path": f"Firmware/{path.name}",
+            "size": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+
+    def invoke(self, manifest: Path, base_ref: str | None = None) -> subprocess.CompletedProcess[str]:
+        command = [sys.executable, "-B", str(SCRIPT), "--manifest", str(manifest)]
+        if base_ref:
+            command.extend(["--base-ref", base_ref])
+        return subprocess.run(
+            command,
+            cwd=self.root, text=True, capture_output=True, check=False,
+        )
+
+    def test_happy_path_and_tamper_fail_closed(self) -> None:
+        content = b"factory-image"
+        binary = self.write_binary("factory.bin", content)
+        manifest = self.write_manifest([self.entry(binary, content)])
+        passed = self.invoke(manifest)
+        self.assertEqual(passed.returncode, 0, passed.stderr)
+        binary.write_bytes(b"changed-image")
+        failed = self.invoke(manifest)
+        self.assertEqual(failed.returncode, 1)
+        self.assertRegex(failed.stdout, r"(SIZE|SHA256)_MISMATCH: Firmware/factory.bin")
+
+    def test_missing_and_unlisted_tracked_binary_fail(self) -> None:
+        content = b"factory-image"
+        binary = self.write_binary("factory.bin", content)
+        manifest = self.write_manifest([self.entry(binary, content)])
+        binary.unlink()
+        missing = self.invoke(manifest)
+        self.assertEqual(missing.returncode, 1)
+        self.assertIn("MISSING_FIRMWARE: Firmware/factory.bin", missing.stdout)
+        binary.write_bytes(content)
+        self.write_binary("unlisted.bin", b"new-image")
+        unlisted = self.invoke(manifest)
+        self.assertEqual(unlisted.returncode, 1)
+        self.assertIn("UNLISTED_TRACKED_FIRMWARE: Firmware/unlisted.bin", unlisted.stdout)
+
+    def test_uppercase_extension_is_not_omitted(self) -> None:
+        content = b"factory-image"
+        binary = self.write_binary("factory.bin", content)
+        manifest = self.write_manifest([self.entry(binary, content)])
+        self.write_binary("unlisted.BIN", b"new-image")
+        result = self.invoke(manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("UNLISTED_TRACKED_FIRMWARE: Firmware/unlisted.BIN", result.stdout)
+
+    def test_base_ref_prevents_binary_and_manifest_replacement(self) -> None:
+        original = b"factory-image"
+        binary = self.write_binary("factory.bin", original)
+        manifest = self.write_manifest([self.entry(binary, original)])
+        subprocess.run(["git", "add", "firmware_integrity.json"], cwd=self.root, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+             "commit", "-q", "-m", "baseline"], cwd=self.root, check=True,
+        )
+        base_ref = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.root, text=True).strip()
+        changed = b"replacement-image"
+        binary.write_bytes(changed)
+        self.write_manifest([self.entry(binary, changed)])
+        result = self.invoke(manifest, base_ref)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("IMMUTABLE_FIRMWARE_CHANGED: Firmware/factory.bin", result.stdout)
+
+    def test_unsafe_and_malformed_manifests_fail_before_hashing(self) -> None:
+        unsafe = self.write_manifest([{
+            "path": "Firmware/nested/factory.bin", "size": 1, "sha256": "0" * 64,
+        }])
+        result = self.invoke(unsafe)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("CONFIG_ERROR:", result.stderr)
+        unsafe.write_text('{"firmware": "not-a-list"}', encoding="utf-8")
+        malformed = self.invoke(unsafe)
+        self.assertEqual(malformed.returncode, 2)
+        self.assertIn("CONFIG_ERROR:", malformed.stderr)
+
+    def test_manifest_symlink_is_rejected(self) -> None:
+        nested = self.root / "nested"
+        nested.mkdir()
+        target = nested / "manifest.json"
+        target.write_text('{"firmware": []}', encoding="utf-8")
+        manifest = self.root / "firmware_integrity.json"
+        manifest.symlink_to(target)
+        result = self.invoke(manifest)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("regular non-symlink", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -1,0 +1,47 @@
+"""Regression checks for the exact lightweight workflow contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO / ".github" / "workflows" / "examples.yml"
+
+
+class WorkflowContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_exact_firmware_identity_command_is_wired(self) -> None:
+        self.assertIn(
+            "python3 -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json",
+            self.workflow,
+        )
+        self.assertIn('--base-ref "$FIRMWARE_BASE_REF"', self.workflow)
+        self.assertIn("github.event.pull_request.base.sha", self.workflow)
+
+    def test_scope_job_consumes_every_classifier_output(self) -> None:
+        self.assertIn("change-scope:", self.workflow)
+        self.assertIn("if: ${{ always() }}", self.workflow)
+        for output in (
+            "docs_only", "firmware", "release_review", "unknown_paths",
+            "firmware_paths", "release_paths",
+        ):
+            self.assertIn(f"needs.discover-esp-idf.outputs.{output}", self.workflow)
+        self.assertIn("needs: [discover-esp-idf, change-scope]", self.workflow)
+        self.assertIn("needs: [discover-arduino, change-scope]", self.workflow)
+
+    def test_workflow_has_no_event_path_filter_that_can_hide_scope_status(self) -> None:
+        self.assertNotIn("paths-ignore:", self.workflow)
+        self.assertNotIn("    paths:", self.workflow)
+
+    def test_matrix_paths_are_passed_through_environment(self) -> None:
+        self.assertIn("PROJECT_PATH: ${{ matrix.path }}", self.workflow)
+        self.assertNotIn('"${{ matrix.path }}"', self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expose documentation, firmware, immutable-release, and unknown-path routing results in an always-visible change-scope job
- add a fail-closed manifest for the two tracked factory firmware binaries
- compare immutable factory binaries with the trusted base SHA on pull requests and branch pushes
- pass repository-derived matrix values to shell steps through quoted environment variables
- document the CI routing and immutable-firmware contract in English and Simplified Chinese

## Scope and compatibility

- no product features, hardware mappings, or factory binaries are changed
- ESP-IDF remains pinned to v5.5.5 and v6.0.2
- Arduino-ESP32 remains pinned to 3.3.11
- the repository discovery matrix contains 17 ESP-IDF projects across two versions and 26 Arduino sketches

## Validation

Non-build checks:

- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover -s tests -v` — 20 tests passed
- `python3 -B scripts/check_repository_policy.py --config repository_policy.json` — passed
- `python3 -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json` — verified two identities
- `python3 -B scripts/check_firmware_integrity.py --manifest firmware_integrity.json --base-ref <base-sha>` — passed
- `git diff --check` — passed
- changed Python files parsed with `ast.parse` — passed
- Markdown audit — 0 errors, 0 warnings
- CI routing audit — full 17-project ESP-IDF and 26-sketch Arduino surfaces selected

Local product builds: waived by user.

GitHub Actions run [#19](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.8/actions/runs/31695100435) on head SHA `232ba545d787fc2c448819a04114e6a28e5f6ba1`: **64/64 jobs passed**.

- repository policy, discovery, and change scope: 4/4
- ESP-IDF v5.5.5: 17/17
- ESP-IDF v6.0.2: 17/17
- Arduino-ESP32 3.3.11: 26/26

## Review notes

The repository does not contain a board-level schematic, so this change makes no new pin or hardware-correctness claims. Factory firmware remains immutable and outside source-build packaging.